### PR TITLE
chore: fix GoReleaser config and option for GoReleaser v2

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,11 +2,10 @@ name: cd
 on:
   push:
     tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
     # デバッグ用
     # branches:
     # - goreleaser_v1.19
-
 
 env:
   REGISTRY: ghcr.io
@@ -23,12 +22,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.22'
+          go-version: ">=1.22"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: gtree
 env:
   - GO111MODULE=on
@@ -48,9 +49,9 @@ brews:
       owner: ddddddO
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    folder: Formula
-    homepage: 'https://github.com/ddddddO/gtree'
-    description: 'This CLI uses Markdown to generate directory trees and directories itself, and also verifies directories.'
+    directory: Formula
+    homepage: "https://github.com/ddddddO/gtree"
+    description: "This CLI uses Markdown to generate directory trees and directories itself, and also verifies directories."
     license: "BSD-2-Clause"
 scoops:
   - repository:


### PR DESCRIPTION
The release workflow failed due to the breaking change of GoReleaser v2.

https://github.com/ddddddO/gtree/actions/runs/10540466053/job/29205156183#step:4:20

```
  ⨯ command failed                                   error=unknown flag: --rm-dist
```

`--rm-dist` was deleted.

https://github.com/ddddddO/gtree/releases/tag/v1.10.11

Releasing assets failed.

<img width="246" alt="image" src="https://github.com/user-attachments/assets/5080f865-3ec2-4329-8211-3e4a4a663419">

- https://goreleaser.com/blog/goreleaser-v2/?h=v2#upgrading
- https://goreleaser.com/deprecations/#brewsfolder

## Test

```console
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```