### PR TITLE
Change show-index to omit-index flg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       #     args: --issues-exit-code=0
 
       - name: test # testだけ各OSで実行
-        run: go test . ./markdown/... -race -coverprofile=coverage.out -covermode=atomic -v
+        run: go test . ./markdown/... ./cmd/xtree/... -race -coverprofile=coverage.out -covermode=atomic -v
 
       - name: upload coverage to Codecov
         if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -757,8 +757,8 @@ USAGE:
    xtree output [options]
 
 OPTIONS:
-   --show-index, --index, -i  set this option when you want to display array element numbers (indices).
-   --allow-duplicate, -a      set this option when you want to allow duplicate node names at the same level
+   --omit-index, --omit, -o   set this option when you do not want to display array indices.
+   --allow-duplicate, -a      set this option when you want to allow duplicate node names at the same level.
    --help, -h                 show help
 ```
 
@@ -787,12 +787,16 @@ $ cat a.json | xtree output
 ├── age
 │   └── 30
 ├── devices
-│   ├── os
-│   │   ├── ios
-│   │   └── windows
-│   └── type
-│       ├── mobile
-│       └── desktop
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
 ├── height
 │   └── 175.5
 ├── is_active
@@ -802,8 +806,10 @@ $ cat a.json | xtree output
 ├── name
 │   └── Alice
 ├── roles
-│   ├── admin
-│   └── editor
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
 └── settings
     ├── notifications
     │   └── true
@@ -837,12 +843,16 @@ $ cat a.toml | xtree output
 ├── age
 │   └── 30
 ├── devices
-│   ├── os
-│   │   ├── ios
-│   │   └── windows
-│   └── type
-│       ├── mobile
-│       └── desktop
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
 ├── height
 │   └── 175.5
 ├── is_active
@@ -850,8 +860,10 @@ $ cat a.toml | xtree output
 ├── name
 │   └── Alice
 ├── roles
-│   ├── admin
-│   └── editor
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
 └── settings
     ├── notifications
     │   └── true
@@ -884,12 +896,16 @@ $ cat a.yaml | xtree output
 ├── age
 │   └── 30
 ├── devices
-│   ├── os
-│   │   ├── ios
-│   │   └── windows
-│   └── type
-│       ├── mobile
-│       └── desktop
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
 ├── height
 │   └── 175.5
 ├── is_active
@@ -899,8 +915,10 @@ $ cat a.yaml | xtree output
 ├── name
 │   └── Alice
 ├── roles
-│   ├── admin
-│   └── editor
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
 └── settings
     ├── notifications
     │   └── true

--- a/cmd/xtree/main.go
+++ b/cmd/xtree/main.go
@@ -35,14 +35,14 @@ func main() {
 					"Let's try 'cat {.json|.yaml|.toml} | xtree output'.",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
-						Name:    "show-index",
-						Aliases: []string{"index", "i"},
-						Usage:   "set this option when you want to display array element numbers (indices).",
+						Name:    "omit-index",
+						Aliases: []string{"omit", "o"},
+						Usage:   "set this option when you do not want to display array indices.",
 					},
 					&cli.BoolFlag{
 						Name:    "allow-duplicate",
 						Aliases: []string{"a"},
-						Usage:   "set this option when you want to allow duplicate node names at the same level",
+						Usage:   "set this option when you want to allow duplicate node names at the same level.",
 					},
 				},
 				Before: notExistArgs,
@@ -71,12 +71,12 @@ func actionOutput(ctx context.Context, c *cli.Command) error {
 	if c.Bool("allow-duplicate") {
 		root = gtree.NewRoot(".", gtree.WithDuplicationAllowed())
 	}
-	showIndex := c.Bool("show-index")
+	omitIndex := c.Bool("omit-index")
 
-	return output(os.Stdout, os.Stdin, root, showIndex)
+	return output(os.Stdout, os.Stdin, root, omitIndex)
 }
 
-func output(w io.Writer, r io.Reader, root *gtree.Node, showIndex bool) error {
+func output(w io.Writer, r io.Reader, root *gtree.Node, omitIndex bool) error {
 	input, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func output(w io.Writer, r io.Reader, root *gtree.Node, showIndex bool) error {
 	if err != nil {
 		return err
 	}
-	walk(root, "", data, showIndex)
+	walk(root, "", data, omitIndex)
 
 	return gtree.OutputFromRoot(w, root)
 }
@@ -106,7 +106,7 @@ func parseData(data []byte) (any, error) {
 	return nil, errors.New("data is in an unsupported format or is invalid")
 }
 
-func walk(parent *gtree.Node, key string, value any, showIndex bool) {
+func walk(parent *gtree.Node, key string, value any, omitIndex bool) {
 	switch v := value.(type) {
 	case map[string]any:
 		node := parent
@@ -121,7 +121,7 @@ func walk(parent *gtree.Node, key string, value any, showIndex bool) {
 		sort.Strings(keys)
 
 		for _, k := range keys {
-			walk(node, k, v[k], showIndex)
+			walk(node, k, v[k], omitIndex)
 		}
 
 	case map[any]any:
@@ -130,7 +130,7 @@ func walk(parent *gtree.Node, key string, value any, showIndex bool) {
 			node = parent.Add(key)
 		}
 		for k, val := range v {
-			walk(node, fmt.Sprintf("%v", k), val, showIndex)
+			walk(node, fmt.Sprintf("%v", k), val, omitIndex)
 		}
 
 	case []any:
@@ -140,11 +140,11 @@ func walk(parent *gtree.Node, key string, value any, showIndex bool) {
 		}
 
 		for i, item := range v {
-			if showIndex {
-				indexNode := node.Add(fmt.Sprintf("[%d]", i))
-				walk(indexNode, "", item, showIndex)
+			if omitIndex {
+				walk(node, "", item, omitIndex)
 			} else {
-				walk(node, "", item, showIndex)
+				indexNode := node.Add(fmt.Sprintf("[%d]", i))
+				walk(indexNode, "", item, omitIndex)
 			}
 		}
 

--- a/cmd/xtree/main_test.go
+++ b/cmd/xtree/main_test.go
@@ -72,7 +72,7 @@ func TestOutput(t *testing.T) {
 		name           string
 		inputData      io.Reader
 		inputRoot      *gtree.Node
-		inputShowIndex bool
+		inputOmitIndex bool
 		want           string
 		wantErr        error
 	}{
@@ -80,7 +80,89 @@ func TestOutput(t *testing.T) {
 			name:           "JSON",
 			inputData:      strings.NewReader(jsonData),
 			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: false,
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── metadata
+│   └── <nil>
+├── name
+│   └── Alice
+├── roles
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name:           "JSON_allow_duplicate",
+			inputData:      strings.NewReader(jsonData),
+			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── metadata
+│   └── <nil>
+├── name
+│   └── Alice
+├── roles
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name:           "JSON_omit_index",
+			inputData:      strings.NewReader(jsonData),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: true,
 			want: strings.TrimPrefix(`
 .
 ├── age
@@ -112,10 +194,10 @@ func TestOutput(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:           "JSON_allow_duplicate",
+			name:           "JSON_allow_duplicate_and_omit_index",
 			inputData:      strings.NewReader(jsonData),
 			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
-			inputShowIndex: false,
+			inputOmitIndex: true,
 			want: strings.TrimPrefix(`
 .
 ├── age
@@ -140,84 +222,6 @@ func TestOutput(t *testing.T) {
 ├── roles
 │   ├── admin
 │   └── editor
-└── settings
-    ├── notifications
-    │   └── true
-    └── theme
-        └── dark
-`, "\n"),
-			wantErr: nil,
-		},
-		{
-			name:           "JSON_allow_duplicate",
-			inputData:      strings.NewReader(jsonData),
-			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
-			inputShowIndex: false,
-			want: strings.TrimPrefix(`
-.
-├── age
-│   └── 30
-├── devices
-│   ├── os
-│   │   └── ios
-│   ├── type
-│   │   └── mobile
-│   ├── os
-│   │   └── windows
-│   └── type
-│       └── desktop
-├── height
-│   └── 175.5
-├── is_active
-│   └── true
-├── metadata
-│   └── <nil>
-├── name
-│   └── Alice
-├── roles
-│   ├── admin
-│   └── editor
-└── settings
-    ├── notifications
-    │   └── true
-    └── theme
-        └── dark
-`, "\n"),
-			wantErr: nil,
-		},
-		{
-			name:           "JSON_show_index",
-			inputData:      strings.NewReader(jsonData),
-			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: true,
-			want: strings.TrimPrefix(`
-.
-├── age
-│   └── 30
-├── devices
-│   ├── [0]
-│   │   ├── os
-│   │   │   └── ios
-│   │   └── type
-│   │       └── mobile
-│   └── [1]
-│       ├── os
-│       │   └── windows
-│       └── type
-│           └── desktop
-├── height
-│   └── 175.5
-├── is_active
-│   └── true
-├── metadata
-│   └── <nil>
-├── name
-│   └── Alice
-├── roles
-│   ├── [0]
-│   │   └── admin
-│   └── [1]
-│       └── editor
 └── settings
     ├── notifications
     │   └── true
@@ -230,18 +234,22 @@ func TestOutput(t *testing.T) {
 			name:           "TOML",
 			inputData:      strings.NewReader(tomlData),
 			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: false,
+			inputOmitIndex: false,
 			want: strings.TrimPrefix(`
 .
 ├── age
 │   └── 30
 ├── devices
-│   ├── os
-│   │   ├── ios
-│   │   └── windows
-│   └── type
-│       ├── mobile
-│       └── desktop
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
 ├── height
 │   └── 175.5
 ├── is_active
@@ -249,8 +257,10 @@ func TestOutput(t *testing.T) {
 ├── name
 │   └── Alice
 ├── roles
-│   ├── admin
-│   └── editor
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
 └── settings
     ├── notifications
     │   └── true
@@ -263,42 +273,7 @@ func TestOutput(t *testing.T) {
 			name:           "TOML_allow_duplicate",
 			inputData:      strings.NewReader(tomlData),
 			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
-			inputShowIndex: false,
-			want: strings.TrimPrefix(`
-.
-├── age
-│   └── 30
-├── devices
-│   ├── os
-│   │   └── ios
-│   ├── type
-│   │   └── mobile
-│   ├── os
-│   │   └── windows
-│   └── type
-│       └── desktop
-├── height
-│   └── 175.5
-├── is_active
-│   └── true
-├── name
-│   └── Alice
-├── roles
-│   ├── admin
-│   └── editor
-└── settings
-    ├── notifications
-    │   └── true
-    └── theme
-        └── dark
-`, "\n"),
-			wantErr: nil,
-		},
-		{
-			name:           "TOML_show_index",
-			inputData:      strings.NewReader(tomlData),
-			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: true,
+			inputOmitIndex: false,
 			want: strings.TrimPrefix(`
 .
 ├── age
@@ -334,10 +309,160 @@ func TestOutput(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:           "TOML_omit_index",
+			inputData:      strings.NewReader(tomlData),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: true,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── os
+│   │   ├── ios
+│   │   └── windows
+│   └── type
+│       ├── mobile
+│       └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── name
+│   └── Alice
+├── roles
+│   ├── admin
+│   └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name:           "TOML_allow_duplicate_and_omit_index",
+			inputData:      strings.NewReader(tomlData),
+			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
+			inputOmitIndex: true,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── os
+│   │   └── ios
+│   ├── type
+│   │   └── mobile
+│   ├── os
+│   │   └── windows
+│   └── type
+│       └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── name
+│   └── Alice
+├── roles
+│   ├── admin
+│   └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
 			name:           "YAML",
 			inputData:      strings.NewReader(yamlData),
 			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: false,
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── metadata
+│   └── <nil>
+├── name
+│   └── Alice
+├── roles
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name:           "YAML_allow_duplicate",
+			inputData:      strings.NewReader(yamlData),
+			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+├── age
+│   └── 30
+├── devices
+│   ├── [0]
+│   │   ├── os
+│   │   │   └── ios
+│   │   └── type
+│   │       └── mobile
+│   └── [1]
+│       ├── os
+│       │   └── windows
+│       └── type
+│           └── desktop
+├── height
+│   └── 175.5
+├── is_active
+│   └── true
+├── metadata
+│   └── <nil>
+├── name
+│   └── Alice
+├── roles
+│   ├── [0]
+│   │   └── admin
+│   └── [1]
+│       └── editor
+└── settings
+    ├── notifications
+    │   └── true
+    └── theme
+        └── dark
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name:           "YAML_omit_index",
+			inputData:      strings.NewReader(yamlData),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: true,
 			want: strings.TrimPrefix(`
 .
 ├── age
@@ -369,10 +494,10 @@ func TestOutput(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:           "YAML_allow_duplicate",
+			name:           "YAML_allow_duplicate_and_omit_index",
 			inputData:      strings.NewReader(yamlData),
 			inputRoot:      gtree.NewRoot(".", gtree.WithDuplicationAllowed()),
-			inputShowIndex: false,
+			inputOmitIndex: true,
 			want: strings.TrimPrefix(`
 .
 ├── age
@@ -397,47 +522,6 @@ func TestOutput(t *testing.T) {
 ├── roles
 │   ├── admin
 │   └── editor
-└── settings
-    ├── notifications
-    │   └── true
-    └── theme
-        └── dark
-`, "\n"),
-			wantErr: nil,
-		},
-		{
-			name:           "YAML_show_index",
-			inputData:      strings.NewReader(yamlData),
-			inputRoot:      gtree.NewRoot("."),
-			inputShowIndex: true,
-			want: strings.TrimPrefix(`
-.
-├── age
-│   └── 30
-├── devices
-│   ├── [0]
-│   │   ├── os
-│   │   │   └── ios
-│   │   └── type
-│   │       └── mobile
-│   └── [1]
-│       ├── os
-│       │   └── windows
-│       └── type
-│           └── desktop
-├── height
-│   └── 175.5
-├── is_active
-│   └── true
-├── metadata
-│   └── <nil>
-├── name
-│   └── Alice
-├── roles
-│   ├── [0]
-│   │   └── admin
-│   └── [1]
-│       └── editor
 └── settings
     ├── notifications
     │   └── true
@@ -453,7 +537,7 @@ func TestOutput(t *testing.T) {
 			t.Parallel()
 
 			ret := &bytes.Buffer{}
-			gotErr := output(ret, tt.inputData, tt.inputRoot, tt.inputShowIndex)
+			gotErr := output(ret, tt.inputData, tt.inputRoot, tt.inputOmitIndex)
 			gotOutput := ret.String()
 
 			if gotErr != nil {
@@ -465,6 +549,101 @@ func TestOutput(t *testing.T) {
 				t.Errorf("\ngot: \n%s\nwant: \n%s", gotOutput, tt.want)
 			}
 
+		})
+	}
+}
+
+func TestOutput_multiRow(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputData      io.Reader
+		inputRoot      *gtree.Node
+		inputOmitIndex bool
+		want           string
+		wantErr        error
+	}{
+		{
+			name: "JSON",
+			inputData: strings.NewReader(strings.TrimSpace(`
+{
+  "description": "This is a sample\ncontaining multiple lines\nwithin a single JSON value."
+}
+`)),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+└── description
+    └── This is a sample\ncontaining multiple lines\nwithin a single JSON value.
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name: "TOML",
+			inputData: strings.NewReader(strings.TrimSpace(`
+[data]
+multiline = """
+This is a multi-line string
+using triple quotes in TOML.
+It allows preserving newlines."""
+
+single = "PPPP"
+`)),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+└── data
+    ├── multiline
+    │   └── This is a multi-line string\nusing triple quotes in TOML.\nIt allows preserving newlines.
+    └── single
+        └── PPPP
+`, "\n"),
+			wantErr: nil,
+		},
+		{
+			name: "YAML",
+			inputData: strings.NewReader(strings.TrimSpace(`
+config:
+  multiline_literal: |
+    line 1
+    line 2
+    line 3
+  multiline_folded: >
+    This text is folded
+    into a single line
+    when parsed.
+`)),
+			inputRoot:      gtree.NewRoot("."),
+			inputOmitIndex: false,
+			want: strings.TrimPrefix(`
+.
+└── config
+    ├── multiline_folded
+    │   └── This text is folded into a single line when parsed.
+    └── multiline_literal
+        └── line 1\nline 2\nline 3\n
+`, "\n"),
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ret := &bytes.Buffer{}
+			gotErr := output(ret, tt.inputData, tt.inputRoot, tt.inputOmitIndex)
+			gotOutput := ret.String()
+
+			if gotErr != nil {
+				if gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("\ngotErr: \n%v\nwantErr: \n%v", gotErr, tt.wantErr)
+				}
+			}
+			if gotOutput != tt.want {
+				t.Errorf("\ngot: \n%s\nwant: \n%s", gotOutput, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
配列はインデックスを表示した方が良いというコメントが2件以上あり、こちらをデフォルトにした方が良さそう
https://www.reddit.com/r/commandline/comments/1ua8rjw/xtree_cli_to_visualize_jsonyamltoml_as_ascii_tree/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

なので、デフォルトで配列要素番号を表示するようにして、フラグで省略するようにした