### PR TITLE
Improve performance of OutputFromRoot func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cmd/xtree/*.json
 cmd/xtree/*.toml
 cmd/xtree/*.yaml
 cmd/xtree/xtree
+benchmark_gtree_treeprint_test.go

--- a/README.md
+++ b/README.md
@@ -1009,7 +1009,85 @@ $ cat a.json | xtree output --level 2 --omit-index
 
 
 # Performance
+## *OutputFromRoot* func
 
+Compared to [*xlab/treeprint*](https://github.com/xlab/treeprint), the `OutputFromRoot` function (and the `Add` method) consumed 1.2 times more memory, but required 1.5 times fewer memory allocations and ran 1.7 times faster.
+
+<details><summary>benchmark</summary>
+
+```console
+$ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
+goos: linux
+goarch: amd64
+cpu: 13th Gen Intel(R) Core(TM) i7-1370P
+BenchmarkGtree-20                    100           1420257 ns/op         2014550 B/op      34221 allocs/op
+BenchmarkTreeprint-20                100           2457864 ns/op         1668032 B/op      52943 allocs/op
+PASS
+ok      command-line-arguments  0.392s
+```
+
+↓`benchmark_gtree_treeprint_test.go`
+```go
+package gtree_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ddddddO/gtree"
+	"github.com/xlab/treeprint"
+)
+
+func BenchmarkGtree(b *testing.B) {
+	for b.Loop() {
+		root := gtree.NewRoot(".")
+		buildGtree(root, 5, 5) // A tree with depth of 5 and width of 5.
+
+		ret := &strings.Builder{}
+		gtree.OutputFromRoot(ret, root)
+		_ = ret.String()
+	}
+}
+
+func buildGtree(parent *gtree.Node, depth, width int) {
+	if depth <= 0 {
+		return
+	}
+	for i := range width {
+		child := parent.Add(fmt.Sprintf("n-%d-%d", depth, i))
+		buildGtree(child, depth-1, width)
+	}
+}
+
+func BenchmarkTreeprint(b *testing.B) {
+	for b.Loop() {
+		tree := treeprint.New()
+		buildTreeprint(tree, 5, 5) // A tree with depth of 5 and width of 5.
+
+		_ = tree.String()
+	}
+}
+
+func buildTreeprint(parent treeprint.Tree, depth, width int) {
+	if depth <= 0 {
+		return
+	}
+	for i := range width {
+		if depth == 1 {
+			parent.AddNode(fmt.Sprintf("n-%d-%d", depth, i))
+		} else {
+			child := parent.AddBranch(fmt.Sprintf("n-%d-%d", depth, i))
+			buildTreeprint(child, depth-1, width)
+		}
+	}
+}
+```
+
+</details>
+
+
+## *Output* func
 <details><summary>see</summary>
 
 ```console

--- a/node.go
+++ b/node.go
@@ -21,7 +21,7 @@ type Node struct {
 }
 
 type branch struct {
-	value string
+	value strings.Builder
 	path  string
 }
 
@@ -47,7 +47,10 @@ func (n *Node) setParent(parent *Node) {
 }
 
 func (n *Node) addChild(child *Node) {
-	n.children = append(n.children, child)
+	tmp := make([]*Node, len(n.children)+1)
+	copy(tmp, n.children)
+	tmp[len(n.children)] = child
+	n.children = tmp
 }
 
 func (n *Node) hasChild() bool {
@@ -88,15 +91,27 @@ func (n *Node) isRoot() bool {
 }
 
 func (n *Node) setBranch(branchs ...string) {
-	var ret strings.Builder
+	n.brnch.value.Reset()
 	for _, v := range branchs {
-		ret.WriteString(v)
+		_, _ = n.brnch.value.WriteString(v)
 	}
-	n.brnch.value = ret.String()
+}
+
+func (n *Node) appendBranch(branch string) {
+	n.brnch.value.Grow(len(branch))
+	n.brnch.value.WriteString(branch)
+}
+
+func (n *Node) prependBranch(branch string) {
+	tmp := strings.Builder{}
+	tmp.Grow(len(branch) + n.brnch.value.Len())
+	tmp.WriteString(branch)
+	tmp.WriteString(n.brnch.value.String())
+	n.brnch.value = tmp
 }
 
 func (n *Node) branch() string {
-	return n.brnch.value
+	return n.brnch.value.String()
 }
 
 func (n *Node) setPath(paths ...string) {

--- a/simple_tree.go
+++ b/simple_tree.go
@@ -108,91 +108,9 @@ func (t *treeSimple) outputProgrammably(w io.Writer, root *Node, cfg *config) er
 		return t.spreader.spread(w, []*Node{root})
 	}
 
-	// JSONなどのフォーマットに変えずに出力する場合は、枝の形成と出力を分けない実装は以下のコード
+	// JSONなどのフォーマットに変えずに出力する場合は、枝の形成と出力を分けない
+	// また、パフォーマンス改善している
 	return t.growSpreader.growAndSpread(w, []*Node{root})
-	// 上記メソッドのベンチマークが以下で、xlab/treeprint と比較してメモリ確保が多かったためCPU負荷が高くなり実行時間も少し上回っていたよう
-	// ↓上がgtree/下がtreeprintのベンチマーク
-	// $ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
-	// goos: linux
-	// goarch: amd64
-	// cpu: 13th Gen Intel(R) Core(TM) i7-1370P
-	// BenchmarkGtree-20                    100           3967348 ns/op         1542957 B/op      70524 allocs/op
-	// BenchmarkTreeprint-20                100           3239239 ns/op         1240660 B/op      38102 allocs/op
-	// PASS
-	// ok      command-line-arguments  0.731s
-
-	// 以下は一度すべての枝を形成してから順次書き込んで出力する方式のコード
-	// if err := t.grower.grow([]*Node{root}); err != nil {
-	// 	return err
-	// }
-	// return t.spreader.spread(w, []*Node{root})
-	// このメソッドのベンチマークは以下で、上記のgrowAndSpreadメソッド版とそう変わらなかった
-	// そこまで大きくないツリーではそうパフォーマンスに問題はないだろうし、仮に大きなツリーが来た場合、spreadメソッドだとユーザーに出力を待たせることになるので、上記の枝の形成と出力を分けない実装でいく
-	// ↓上がgtree/下がtreeprintのベンチマーク
-	// $ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
-	// goos: linux
-	// goarch: amd64
-	// cpu: 13th Gen Intel(R) Core(TM) i7-1370P
-	// BenchmarkGtree-20                    100           3827116 ns/op         1522339 B/op      70526 allocs/op
-	// BenchmarkTreeprint-20                100           3181960 ns/op         1240704 B/op      38102 allocs/op
-	// PASS
-	// ok      command-line-arguments  0.709s
-
-	// 以下は、上記のベンチマーク用のコード。外部のライブラリがgo.modに入るのは嫌なのでコメントアウトでメモしてる
-
-	// package gtree_test
-
-	// import (
-	// 	"fmt"
-	// 	"io"
-	// 	"testing"
-
-	// 	"github.com/ddddddO/gtree"
-	// 	"github.com/xlab/treeprint"
-	// )
-
-	// func BenchmarkGtree(b *testing.B) {
-	// 	root := gtree.NewRoot("root")
-	// 	buildGtree(root, 5, 5) // 深さ5, 幅5 のツリー
-
-	// 	for b.Loop() {
-	// 		_ = gtree.OutputFromRoot(io.Discard, root)
-	// 	}
-	// }
-
-	// func buildGtree(parent *gtree.Node, depth, width int) {
-	// 	if depth <= 0 {
-	// 		return
-	// 	}
-	// 	for i := range width {
-	// 		child := parent.Add(fmt.Sprintf("n-%d-%d", depth, i))
-	// 		buildGtree(child, depth-1, width)
-	// 	}
-	// }
-
-	// func BenchmarkTreeprint(b *testing.B) {
-	// 	tree := treeprint.New()
-	// 	buildTreeprint(tree, 5, 5) // 深さ5, 幅5 のツリー
-
-	// 	for b.Loop() {
-	// 		_ = tree.String()
-	// 	}
-	// }
-
-	// func buildTreeprint(parent treeprint.Tree, depth, width int) {
-	// 	if depth <= 0 {
-	// 		return
-	// 	}
-	// 	for i := range width {
-	// 		if depth == 1 {
-	// 			parent.AddNode(fmt.Sprintf("n-%d-%d", depth, i))
-	// 		} else {
-	// 			child := parent.AddBranch(fmt.Sprintf("n-%d-%d", depth, i))
-	// 			buildTreeprint(child, depth-1, width)
-	// 		}
-	// 	}
-	// }
-
 }
 
 func (t *treeSimple) mkdir(r io.Reader, cfg *config) error {

--- a/simple_tree_grow_spreader.go
+++ b/simple_tree_grow_spreader.go
@@ -3,7 +3,7 @@
 package gtree
 
 import (
-	"fmt"
+	"bytes"
 	"io"
 )
 
@@ -39,11 +39,19 @@ func (dgs *defaultGrowSpreaderSimple) assembleAndPrint(current *Node) error {
 		return err
 	}
 
-	ret := current.name + "\n"
-	if !current.isRoot() {
-		ret = current.branch() + " " + current.name + "\n"
+	ret := &bytes.Buffer{}
+	if current.isRoot() {
+		ret.Grow(len(current.name) + len("\n"))
+		_, _ = ret.WriteString(current.name)
+		_, _ = ret.WriteString("\n")
+	} else {
+		ret.Grow(current.brnch.value.Len() + len(" ") + len(current.name) + len("\n"))
+		_, _ = ret.WriteString(current.branch())
+		_, _ = ret.WriteString(" ")
+		_, _ = ret.WriteString(current.name)
+		_, _ = ret.WriteString("\n")
 	}
-	fmt.Fprint(dgs.w, ret)
+	_, _ = dgs.w.Write(ret.Bytes())
 
 	for _, child := range current.children {
 		if err := dgs.assembleAndPrint(child); err != nil {
@@ -51,6 +59,50 @@ func (dgs *defaultGrowSpreaderSimple) assembleAndPrint(current *Node) error {
 		}
 	}
 	return nil
+}
+
+// 以降、simple_tree_grower.go の assembleBranch系メソッドとの違いは、setPathの有無
+// こっちのメソッドはOutputFromRootからプログラム的に呼び出されるもので、パフォーマンスを気にする必要がある
+// そして、Node.setPathの有無でベンチマークを取ると、ない方が圧倒的に改善がみられた
+// setPathが必要なのはMkdir系関数なので、こちらのメソッドにはsetPath(と関連の処理)は不要なため落としている
+func (dgs *defaultGrowSpreaderSimple) assembleBranch(current *Node) error {
+	current.clean()
+
+	dgs.assembleBranchDirectly(current)
+
+	// go back to the root to form a branch.
+	tmpParent := current.parent
+	if tmpParent != nil {
+		for ; !tmpParent.isRoot(); tmpParent = tmpParent.parent {
+			dgs.assembleBranchIndirectly(current, tmpParent)
+		}
+	}
+
+	return nil
+}
+
+func (dgs *defaultGrowSpreaderSimple) assembleBranchDirectly(current *Node) {
+	if current == nil || current.isRoot() {
+		return
+	}
+
+	if current.isLastOfHierarchy() {
+		current.appendBranch(dgs.lastNodeFormat.directly)
+	} else {
+		current.appendBranch(dgs.intermedialNodeFormat.directly)
+	}
+}
+
+func (dgs *defaultGrowSpreaderSimple) assembleBranchIndirectly(current, parent *Node) {
+	if current == nil || parent == nil || current.isRoot() {
+		return
+	}
+
+	if parent.isLastOfHierarchy() {
+		current.prependBranch(dgs.lastNodeFormat.indirectly)
+	} else {
+		current.prependBranch(dgs.intermedialNodeFormat.indirectly)
+	}
 }
 
 var (


### PR DESCRIPTION
## Before

```console
ddddddo@debian:~/github.com/ddddddO/gtree$ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
goos: linux
goarch: amd64
cpu: 13th Gen Intel(R) Core(TM) i7-1370P
BenchmarkGtree-20                    100           3194747 ns/op         2823734 B/op      86173 allocs/op
BenchmarkTreeprint-20                100           2423247 ns/op         1668025 B/op      52943 allocs/op
PASS
ok      command-line-arguments  0.566s
```

## After

```console
ddddddo@debian:~/github.com/ddddddO/gtree$ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
goos: linux
goarch: amd64
cpu: 13th Gen Intel(R) Core(TM) i7-1370P
BenchmarkGtree-20                    100           1394024 ns/op         2014498 B/op      34221 allocs/op
BenchmarkTreeprint-20                100           2423380 ns/op         1667979 B/op      52943 allocs/op
PASS
ok      command-line-arguments  0.386s
```


## code

```go
package gtree_test

import (
	"fmt"
	"strings"
	"testing"

	"github.com/ddddddO/gtree"
	"github.com/xlab/treeprint"
)

func BenchmarkGtree(b *testing.B) {
	for b.Loop() {
		root := gtree.NewRoot(".")
		buildGtree(root, 5, 5) // A tree with depth of 5 and width of 5.

		ret := &strings.Builder{}
		gtree.OutputFromRoot(ret, root)
		_ = ret.String()
	}
}

func buildGtree(parent *gtree.Node, depth, width int) {
	if depth <= 0 {
		return
	}
	for i := range width {
		child := parent.Add(fmt.Sprintf("n-%d-%d", depth, i))
		buildGtree(child, depth-1, width)
	}
}

func BenchmarkTreeprint(b *testing.B) {
	for b.Loop() {
		tree := treeprint.New()
		buildTreeprint(tree, 5, 5) // A tree with depth of 5 and width of 5.

		_ = tree.String()
	}
}

func buildTreeprint(parent treeprint.Tree, depth, width int) {
	if depth <= 0 {
		return
	}
	for i := range width {
		if depth == 1 {
			parent.AddNode(fmt.Sprintf("n-%d-%d", depth, i))
		} else {
			child := parent.AddBranch(fmt.Sprintf("n-%d-%d", depth, i))
			buildTreeprint(child, depth-1, width)
		}
	}
}
```