### PR TITLE
Improved memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,7 +1011,7 @@ $ cat a.json | xtree output --level 2 --omit-index
 # Performance
 ## *OutputFromRoot* func
 
-Compared to [*xlab/treeprint*](https://github.com/xlab/treeprint), the `OutputFromRoot` function (and the `Add` method) consumed 1.17 times more memory, but required 1.55 times fewer memory allocations and ran 2.04 times faster.
+Compared to [*xlab/treeprint*](https://github.com/xlab/treeprint), the `OutputFromRoot` function (and the `Add` method) consumed 1.02 times more memory, but required 1.75 times fewer memory allocations and ran 2.04 times faster.
 
 <details><summary>benchmark</summary>
 
@@ -1020,10 +1020,10 @@ $ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_t
 goos: linux
 goarch: amd64
 cpu: 13th Gen Intel(R) Core(TM) i7-1370P
-BenchmarkGtree-20                    100           2252606 ns/op         1951766 B/op      34220 allocs/op
-BenchmarkTreeprint-20                100           4596705 ns/op         1668049 B/op      52943 allocs/op
+BenchmarkGtree-20                    100           1252058 ns/op         1702880 B/op      30314 allocs/op
+BenchmarkTreeprint-20                100           2547779 ns/op         1668006 B/op      52943 allocs/op
 PASS
-ok      command-line-arguments  0.691s
+ok      command-line-arguments  0.385s
 ```
 
 ↓`benchmark_gtree_treeprint_test.go`

--- a/simple_tree_grow_spreader.go
+++ b/simple_tree_grow_spreader.go
@@ -3,7 +3,6 @@
 package gtree
 
 import (
-	"bytes"
 	"io"
 )
 
@@ -39,19 +38,15 @@ func (dgs *defaultGrowSpreaderSimple) assembleAndPrint(current *Node) error {
 		return err
 	}
 
-	ret := &bytes.Buffer{}
 	if current.isRoot() {
-		ret.Grow(len(current.value) + len("\n"))
-		_, _ = ret.WriteString(current.value)
-		_, _ = ret.WriteString("\n")
+		_, _ = io.WriteString(dgs.w, current.value)
+		_, _ = io.WriteString(dgs.w, "\n")
 	} else {
-		ret.Grow(current.brnch.value.Len() + len(" ") + len(current.value) + len("\n"))
-		_, _ = ret.WriteString(current.branch())
-		_, _ = ret.WriteString(" ")
-		_, _ = ret.WriteString(current.value)
-		_, _ = ret.WriteString("\n")
+		_, _ = io.WriteString(dgs.w, current.branch())
+		_, _ = io.WriteString(dgs.w, " ")
+		_, _ = io.WriteString(dgs.w, current.value)
+		_, _ = io.WriteString(dgs.w, "\n")
 	}
-	_, _ = dgs.w.Write(ret.Bytes())
 
 	for _, child := range current.children {
 		if err := dgs.assembleAndPrint(child); err != nil {


### PR DESCRIPTION
## Before
```console
$ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
goos: linux
goarch: amd64
cpu: 13th Gen Intel(R) Core(TM) i7-1370P
BenchmarkGtree-20                    100           1350586 ns/op         1951928 B/op      34221 allocs/op
BenchmarkTreeprint-20                100           2571475 ns/op         1668096 B/op      52943 allocs/op
PASS
ok      command-line-arguments  0.396s
```

## After
```console
$ go test -benchmem -bench Benchmark -benchtime 100x benchmark_gtree_treeprint_test.go
goos: linux
goarch: amd64
cpu: 13th Gen Intel(R) Core(TM) i7-1370P
BenchmarkGtree-20                    100           1252058 ns/op         1702880 B/op      30314 allocs/op
BenchmarkTreeprint-20                100           2547779 ns/op         1668006 B/op      52943 allocs/op
PASS
ok      command-line-arguments  0.385s
```

## code
```go
package gtree_test

import (
	"fmt"
	"strings"
	"testing"

	"github.com/ddddddO/gtree"
	"github.com/xlab/treeprint"
)

func BenchmarkGtree(b *testing.B) {
	for b.Loop() {
		root := gtree.NewRoot(".")
		buildGtree(root, 5, 5) // A tree with depth of 5 and width of 5.

		ret := &strings.Builder{}
		gtree.OutputFromRoot(ret, root)
		_ = ret.String()
	}
}

func buildGtree(parent *gtree.Node, depth, width int) {
	if depth <= 0 {
		return
	}
	for i := range width {
		child := parent.Add(fmt.Sprintf("n-%d-%d", depth, i))
		buildGtree(child, depth-1, width)
	}
}

func BenchmarkTreeprint(b *testing.B) {
	for b.Loop() {
		tree := treeprint.New()
		buildTreeprint(tree, 5, 5) // A tree with depth of 5 and width of 5.

		_ = tree.String()
	}
}

func buildTreeprint(parent treeprint.Tree, depth, width int) {
	if depth <= 0 {
		return
	}
	for i := range width {
		if depth == 1 {
			parent.AddNode(fmt.Sprintf("n-%d-%d", depth, i))
		} else {
			child := parent.AddBranch(fmt.Sprintf("n-%d-%d", depth, i))
			buildTreeprint(child, depth-1, width)
		}
	}
}
```